### PR TITLE
Fix return value of LoginController->determineBackendFor

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -271,7 +271,7 @@ class LoginController extends Controller
 					throw new \InvalidArgumentException("Backend $class returned more than one user for $samlNameId: " . implode(', ', $userIds));
 			}
 		}
-		return [];
+		return null;
 	}
 
 


### PR DESCRIPTION
The default return value of _LoginController->determineBackendFor_ should be null, otherwise IMO [this assertion](https://github.com/owncloud/sociallogin/blob/c878ccf49100a36f74d47644112f685ef5262374/lib/Controller/LoginController.php#L282) would be meaningless.